### PR TITLE
Update to Go 1.22

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15-alpine
+FROM golang:1.22-alpine
 WORKDIR /src
 RUN apk --no-cache add git
 COPY *.go go.mod go.sum ./

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/teralytics/prometheus-ecs-discovery
 
-go 1.15
+go 1.22
 
 require (
 	github.com/aws/aws-sdk-go-v2/config v1.1.4
@@ -9,6 +9,14 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/ecs v1.2.1
 	github.com/aws/aws-sdk-go-v2/service/sts v1.2.1
 	github.com/aws/smithy-go v1.3.0
-	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/go-yaml/yaml v2.1.0+incompatible
+)
+
+require (
+	github.com/aws/aws-sdk-go-v2 v1.3.1 // indirect
+	github.com/aws/aws-sdk-go-v2/feature/ec2/imds v1.0.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/internal/presigned-url v1.0.5 // indirect
+	github.com/aws/aws-sdk-go-v2/service/sso v1.1.4 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/jmespath/go-jmespath v0.4.0 // indirect
 )


### PR DESCRIPTION
## Summary
- update the module to target Go 1.22 and refresh the indirect dependency block generated by `go mod tidy`
- move the build container image to golang:1.22-alpine to match the new toolchain

## Testing
- `go test ./...`


------
https://chatgpt.com/codex/tasks/task_b_68d052e6eeb8832eba1833837e31b8ec